### PR TITLE
Build docker more often to (try)fix tags

### DIFF
--- a/.github/workflows/publish-release-to-ghp.yaml
+++ b/.github/workflows/publish-release-to-ghp.yaml
@@ -61,6 +61,7 @@ jobs:
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see [Using artifact attestations to establish provenance for builds](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds).
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
+        if: ${{ github.event_name != 'pull_request' }}
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.push.outputs.digest }}


### PR DESCRIPTION
This makes a few important changes to how actions work:

- stop worrying about the "release" branch since that's too much
- grab tagging for docker from tag builds, hopefully, so that they get tagged with versions and latest when git has that
- also build MRs (but don't push them) so that we can debug pre-merge in the future